### PR TITLE
Prevent three queries

### DIFF
--- a/lib/chewy/type/adapter/mongoid.rb
+++ b/lib/chewy/type/adapter/mongoid.rb
@@ -30,6 +30,40 @@ module Chewy
           end.all?
         end
 
+        def import_objects(collection, options)
+          collection_ids = identify(collection)
+          hash = Hash[collection_ids.map(&:to_s).zip(collection)]
+
+          direct_import = (collection.is_a?(Array) &&
+                           !collection.empty? &&
+                           collection.all? { |item| item.is_a?(::Mongoid::Document) && item.__selected_fields.nil? })
+
+          indexed = collection_ids.each_slice(options[:batch_size]).map do |ids|
+            batch = if options[:raw_import]
+              raw_default_scope_where_ids_in(ids, options[:raw_import])
+            elsif direct_import
+              hash.values_at(*ids.map(&:to_s))
+            else
+              default_scope_where_ids_in(ids)
+            end
+
+            batch = batch.to_a
+
+            if batch.empty?
+              true
+            else
+              batch.each { |object| hash.delete(object.send(primary_key).to_s) }
+              yield grouped_objects(batch)
+            end
+          end.all?
+
+          deleted = hash.keys.each_slice(options[:batch_size]).map do |group|
+            yield delete: hash.values_at(*group)
+          end.all?
+
+          indexed && deleted
+        end
+
         def primary_key
           :_id
         end

--- a/lib/chewy/type/adapter/mongoid.rb
+++ b/lib/chewy/type/adapter/mongoid.rb
@@ -34,7 +34,8 @@ module Chewy
           collection_ids = identify(collection)
           hash = Hash[collection_ids.map(&:to_s).zip(collection)]
 
-          direct_import = (collection.is_a?(Array) &&
+          direct_import = (default_scope.selector.empty? &&
+                           collection.is_a?(Array) &&
                            !collection.empty? &&
                            collection.all? { |item| item.is_a?(::Mongoid::Document) && item.__selected_fields.nil? })
 


### PR DESCRIPTION
Logic:
- Prevent chewy from doing a count + fetch + fetch  query. Instead, do a fetch only (and just use array length. [Find and count have same performance ](https://stackoverflow.com/questions/52950672/why-mongodb-find-has-same-performance-as-count/52951174)
- If you passed a list of `Mongoid::Document`, we should not do a mongo query to fetch them again. There are two important conditions.
  - `doc.__selected_fields` has to be nil. It means that it wasn't queried with `.only(*fields)`
  - `default_scope` / `indexable_criteria` has to be empty. There is no builtin way to check if a `Mongoid::Document` satisfies a `Mongoid::Criteria` other than querying mongo. So I will leave it to future optimization to manually define a corresponding proc on each of our indexable_criteria functions.
 
<img width="702" alt="Screen Shot 2021-05-14 at 12 09 04 AM" src="https://user-images.githubusercontent.com/11026445/118296345-6e9f4280-b50f-11eb-9fea-6b7fa84e235f.png">

https://github.com/apolloio/leadgenie/pull/5952
