### PR TITLE
Fix deprecated ruby  2.7 syntax

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -132,7 +132,7 @@ module Chewy
     def create_type(index, target, options = {}, &block)
       type = Class.new(Chewy::Type)
 
-      adapter = adapters.find { |klass| klass.accepts?(target) }.new(target, options)
+      adapter = adapters.find { |klass| klass.accepts?(target) }.new(target, **options)
 
       index.const_set(adapter.name, type)
       type.send(:define_singleton_method, :index) { index }

--- a/lib/chewy/fields/base.rb
+++ b/lib/chewy/fields/base.rb
@@ -7,7 +7,7 @@ module Chewy
       def initialize(name, value: nil, **options)
         @name = name.to_sym
         @options = {}
-        update_options!(options)
+        update_options!(**options)
         @value = value
         @children = []
       end

--- a/lib/chewy/fields/root.rb
+++ b/lib/chewy/fields/root.rb
@@ -6,8 +6,8 @@ module Chewy
       attr_reader :parent
       attr_reader :parent_id
 
-      def initialize(*)
-        super
+      def initialize(name, **options)
+        super(name, **options)
 
         @value ||= -> { self }
         @dynamic_templates = []

--- a/lib/chewy/query/loading.rb
+++ b/lib/chewy/query/loading.rb
@@ -94,7 +94,7 @@ module Chewy
         loaded_objects = Hash[_results.group_by(&:class).map do |type, objects|
           next if except.include?(type.type_name)
           next if only.present? && !only.include?(type.type_name)
-          loaded = type.adapter.load(objects.map(&:id), options.merge(_type: type)) || objects
+          loaded = type.adapter.load(objects.map(&:id), **options.merge(_type: type)) || objects
           [type, loaded.index_by.with_index do |loaded_object, i|
             objects[i]._object = loaded_object
             objects[i]

--- a/lib/chewy/search/loader.rb
+++ b/lib/chewy/search/loader.rb
@@ -52,9 +52,8 @@ module Chewy
 
           type = derive_type(index_name, type_name)
           ids = hit_group.map { |hit| hit['_id'] }
-          loaded = type.adapter.load(ids, @options.merge(_type: type))
           loaded = type.adapter.load(ids, **@options.merge(_type: type))
-
+          loaded ||= hit_group.map { |hit| type.build(hit) }
           result.merge!(hit_group.zip(loaded).to_h)
         end
 

--- a/lib/chewy/search/loader.rb
+++ b/lib/chewy/search/loader.rb
@@ -53,7 +53,7 @@ module Chewy
           type = derive_type(index_name, type_name)
           ids = hit_group.map { |hit| hit['_id'] }
           loaded = type.adapter.load(ids, @options.merge(_type: type))
-          loaded ||= hit_group.map { |hit| type.build(hit) }
+          loaded = type.adapter.load(ids, **@options.merge(_type: type))
 
           result.merge!(hit_group.zip(loaded).to_h)
         end

--- a/lib/chewy/type/adapter/active_record.rb
+++ b/lib/chewy/type/adapter/active_record.rb
@@ -22,7 +22,7 @@ module Chewy
         end
 
         def import_scope(scope, options)
-          pluck_in_batches(scope, options.slice(:batch_size)).inject(true) do |result, ids|
+          pluck_in_batches(scope, **options.slice(:batch_size)).inject(true) do |result, ids|
             objects = if options[:raw_import]
               raw_default_scope_where_ids_in(ids, options[:raw_import])
             else

--- a/lib/chewy/type/adapter/mongoid.rb
+++ b/lib/chewy/type/adapter/mongoid.rb
@@ -25,7 +25,7 @@ module Chewy
         end
 
         def import_scope(scope, options)
-          pluck_in_batches(scope, options.slice(:batch_size)).map do |ids|
+          pluck_in_batches(scope, **options.slice(:batch_size)).map do |ids|
             yield grouped_objects(default_scope_where_ids_in(ids))
           end.all?
         end

--- a/lib/chewy/type/adapter/orm.rb
+++ b/lib/chewy/type/adapter/orm.rb
@@ -89,7 +89,7 @@ module Chewy
 
           if options[:fields].present? || collection.is_a?(relation_class)
             collection = all_scope_where_ids_in(identify(collection)) unless collection.is_a?(relation_class)
-            pluck_in_batches(collection, options.slice(:fields, :batch_size, :typecast), &block)
+            pluck_in_batches(collection, **options.slice(:fields, :batch_size, :typecast), &block)
           else
             identify(collection).each_slice(options[:batch_size]) do |batch|
               yield batch

--- a/lib/chewy/type/adapter/sequel.rb
+++ b/lib/chewy/type/adapter/sequel.rb
@@ -22,7 +22,7 @@ module Chewy
         end
 
         def import_scope(scope, options)
-          pluck_in_batches(scope, options.slice(:batch_size)).inject(true) do |result, ids|
+          pluck_in_batches(scope, **options.slice(:batch_size)).inject(true) do |result, ids|
             result & yield(grouped_objects(default_scope_where_ids_in(ids).all))
           end
         end

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -10,7 +10,7 @@ module Chewy
 
       IMPORT_WORKER = lambda do |type, options, total, ids, index|
         ::Process.setproctitle("chewy [#{type}]: import data (#{index + 1}/#{total})")
-        routine = Routine.new(type, options)
+        routine = Routine.new(type, **options)
         type.adapter.import(*ids, routine.options) do |action_objects|
           routine.process(**action_objects)
         end
@@ -19,7 +19,7 @@ module Chewy
 
       LEFTOVERS_WORKER = lambda do |type, options, total, body, index|
         ::Process.setproctitle("chewy [#{type}]: import leftovers (#{index + 1}/#{total})")
-        routine = Routine.new(type, options)
+        routine = Routine.new(type, **options)
         routine.perform_bulk(body)
         routine.errors
       end
@@ -127,7 +127,7 @@ module Chewy
 
         def import_routine(*args)
           return if args.first.blank? && !args.first.nil?
-          routine = Routine.new(self, args.extract_options!)
+          routine = Routine.new(self, **args.extract_options!)
           routine.create_indexes!
 
           if routine.parallel_options

--- a/lib/chewy/type/import/routine.rb
+++ b/lib/chewy/type/import/routine.rb
@@ -66,7 +66,7 @@ module Chewy
         def create_indexes!
           Chewy::Stash::Journal.create if @options[:journal]
           return if Chewy.configuration[:skip_index_creation_on_import]
-          @type.index.create!(@bulk_options.slice(:suffix)) unless @type.index.exists?
+          @type.index.create!(**@bulk_options.slice(:suffix)) unless @type.index.exists?
         end
 
         # The main process method. Converts passed objects to thr bulk request body,

--- a/lib/chewy/type/mapping.rb
+++ b/lib/chewy/type/mapping.rb
@@ -35,8 +35,8 @@ module Chewy
         #   end
         #
         def root(**options)
-          self.root_object ||= Chewy::Fields::Root.new(type_name, Chewy.default_root_options.merge(options))
-          root_object.update_options!(options)
+          self.root_object ||= Chewy::Fields::Root.new(type_name, **Chewy.default_root_options.merge(options))
+          root_object.update_options!(**options)
           yield if block_given?
           root_object
         end
@@ -126,9 +126,9 @@ module Chewy
         #
         def field(*args, **options, &block)
           if args.size > 1
-            args.map { |name| field(name, options) }
+            args.map { |name| field(name, **options) }
           else
-            expand_nested(Chewy::Fields::Base.new(args.first, options), &block)
+            expand_nested(Chewy::Fields::Base.new(args.first, **options), &block)
           end
         end
 

--- a/spec/chewy/journal_spec.rb
+++ b/spec/chewy/journal_spec.rb
@@ -54,7 +54,7 @@ describe Chewy::Journal do
             expect(Chewy::Stash::Journal.exists?).to eq true
 
             Timecop.freeze(update_time)
-            cities.first.update_attributes!(name: 'Supername')
+            cities.first.update!(name: 'Supername')
 
             Timecop.freeze(destroy_time)
             countries.last.destroy

--- a/spec/chewy/type/import/bulk_builder_spec.rb
+++ b/spec/chewy/type/import/bulk_builder_spec.rb
@@ -117,7 +117,7 @@ describe Chewy::Type::Import::BulkBuilder do
       context 'updating parent' do
         before do
           PlacesIndex::City.import(city)
-          city.update_attributes(country_id: another_country.id)
+          city.update(country_id: another_country.id)
         end
         let(:index) { [city] }
 

--- a/spec/chewy/type/observe_spec.rb
+++ b/spec/chewy/type/observe_spec.rb
@@ -75,11 +75,11 @@ describe Chewy::Type::Observe do
       specify { expect { city.save! }.to update_index('cities#city').and_reindex(city).only }
       specify { expect { city.save! }.to update_index('countries#country').and_reindex(country1).only }
 
-      specify { expect { city.update_attributes!(country: nil) }.to update_index('cities#city').and_reindex(city).only }
-      specify { expect { city.update_attributes!(country: nil) }.to update_index('countries#country').and_reindex(country1).only }
+      specify { expect { city.update!(country: nil) }.to update_index('cities#city').and_reindex(city).only }
+      specify { expect { city.update!(country: nil) }.to update_index('countries#country').and_reindex(country1).only }
 
-      specify { expect { city.update_attributes!(country: country2) }.to update_index('cities#city').and_reindex(city).only }
-      specify { expect { city.update_attributes!(country: country2) }.to update_index('countries#country').and_reindex(country1, country2).only }
+      specify { expect { city.update!(country: country2) }.to update_index('cities#city').and_reindex(city).only }
+      specify { expect { city.update!(country: country2) }.to update_index('countries#country').and_reindex(country1, country2).only }
     end
 
     context do


### PR DESCRIPTION
<img width="1134" alt="Screenshot 2021-07-29 at 09 32 42" src="https://user-images.githubusercontent.com/13007654/127459406-8a621ae5-2098-4fa9-a919-c72fd3006362.png">

Fixes deprecation warnings and Errors
```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call