### PR TITLE
NOTICKET pass update_fields to crutch

### DIFF
--- a/lib/chewy/type/crutch.rb
+++ b/lib/chewy/type/crutch.rb
@@ -12,10 +12,11 @@ module Chewy
         def initialize(type, collection, update_fields: [])
           @type = type
           @collection = collection
+          @update_fields = update_fields
           @type._crutches.each_key do |name|
             singleton_class.class_eval <<-METHOD, __FILE__, __LINE__ + 1
               def #{name}
-                @#{name} ||= @type._crutches[:#{name}].call @collection, update_fields 
+                @#{name} ||= @type._crutches[:#{name}].call @collection, update_fields: @update_fields 
               end
             METHOD
           end

--- a/lib/chewy/type/crutch.rb
+++ b/lib/chewy/type/crutch.rb
@@ -9,13 +9,13 @@ module Chewy
       end
 
       class Crutches
-        def initialize(type, collection)
+        def initialize(type, collection, update_fields: [])
           @type = type
           @collection = collection
           @type._crutches.each_key do |name|
             singleton_class.class_eval <<-METHOD, __FILE__, __LINE__ + 1
               def #{name}
-                @#{name} ||= @type._crutches[:#{name}].call @collection
+                @#{name} ||= @type._crutches[:#{name}].call @collection, update_fields 
               end
             METHOD
           end

--- a/lib/chewy/type/crutch.rb
+++ b/lib/chewy/type/crutch.rb
@@ -16,7 +16,7 @@ module Chewy
           @type._crutches.each_key do |name|
             singleton_class.class_eval <<-METHOD, __FILE__, __LINE__ + 1
               def #{name}
-                @#{name} ||= @type._crutches[:#{name}].call @collection, update_fields: @update_fields 
+                @#{name} ||= @type._crutches[:#{name}].call @collection, @update_fields 
               end
             METHOD
           end

--- a/lib/chewy/type/import/bulk_builder.rb
+++ b/lib/chewy/type/import/bulk_builder.rb
@@ -40,7 +40,7 @@ module Chewy
       private
 
         def crutches
-          @crutches ||= Chewy::Type::Crutch::Crutches.new @type, @index
+          @crutches ||= Chewy::Type::Crutch::Crutches.new @type, @index, update_fields: @fields
         end
 
         def parents

--- a/lib/chewy/type/import/bulk_builder.rb
+++ b/lib/chewy/type/import/bulk_builder.rb
@@ -18,11 +18,6 @@ module Chewy
           @index = index
           @delete = delete
           @fields = fields.map!(&:to_sym)
-          puts " ===== "
-          puts @type
-          puts @index
-          puts @fields
-          puts " ===== "
         end
 
         # Returns ES API-ready bulk requiest body.

--- a/lib/chewy/type/import/bulk_builder.rb
+++ b/lib/chewy/type/import/bulk_builder.rb
@@ -18,6 +18,11 @@ module Chewy
           @index = index
           @delete = delete
           @fields = fields.map!(&:to_sym)
+          puts " ===== "
+          puts @type
+          puts @index
+          puts @fields
+          puts " ===== "
         end
 
         # Returns ES API-ready bulk requiest body.

--- a/lib/chewy/type/import/bulk_builder.rb
+++ b/lib/chewy/type/import/bulk_builder.rb
@@ -40,7 +40,7 @@ module Chewy
       private
 
         def crutches
-          @crutches ||= Chewy::Type::Crutch::Crutches.new @type, @index, update_fields: @fields
+          @crutches ||= Chewy::Type::Crutch::Crutches.new(@type, @index, update_fields: @fields)
         end
 
         def parents

--- a/lib/chewy/type/import/bulk_builder.rb
+++ b/lib/chewy/type/import/bulk_builder.rb
@@ -40,7 +40,7 @@ module Chewy
       private
 
         def crutches
-          @crutches ||= Chewy::Type::Crutch::Crutches.new(@type, @index, update_fields: @fields)
+          @crutches ||= Chewy::Type::Crutch::Crutches.new @type, @index, update_fields: @fields
         end
 
         def parents

--- a/lib/chewy/type/import/routine.rb
+++ b/lib/chewy/type/import/routine.rb
@@ -78,7 +78,6 @@ module Chewy
         # @return [true, false] the result of the request, true if no errors
         def process(index: [], delete: [])
           bulk_builder = BulkBuilder.new(@type, index: index, delete: delete, fields: @options[:update_fields])
-          puts bulk_builder
           bulk_body = bulk_builder.bulk_body
 
           if @options[:journal]

--- a/lib/chewy/type/import/routine.rb
+++ b/lib/chewy/type/import/routine.rb
@@ -118,11 +118,15 @@ module Chewy
         def extract_leftovers(errors, index_objects_by_id)
           return [] unless @options[:update_fields].present? && @options[:update_failover] && errors.present?
 
+          puts "errors #{errors}"
+          puts "@options[:update_failover] #{@options[:update_failover]}"
           puts "extract_leftovers"
           failed_partial_updates = errors.select do |item|
             item.keys.first == 'update' && item.values.first['error']['type'] == 'document_missing_exception'
           end
+          puts "failed_partial_updates #{failed_partial_updates}"
           failed_ids_hash = failed_partial_updates.index_by { |item| item.values.first['_id'].to_s }
+          puts "failed_ids_hash #{failed_ids_hash}"
           failed_ids_for_reimport = failed_ids_hash.keys & index_objects_by_id.keys
           errors_to_cleanup = failed_ids_hash.values_at(*failed_ids_for_reimport)
           errors_to_cleanup.each { |error| errors.delete(error) }

--- a/lib/chewy/type/import/routine.rb
+++ b/lib/chewy/type/import/routine.rb
@@ -77,6 +77,7 @@ module Chewy
         # @param delete [Array<Object>] any acceptable objects for deleting
         # @return [true, false] the result of the request, true if no errors
         def process(index: [], delete: [])
+          puts "inside process"
           bulk_builder = BulkBuilder.new(@type, index: index, delete: delete, fields: @options[:update_fields])
           bulk_body = bulk_builder.bulk_body
 
@@ -117,6 +118,7 @@ module Chewy
         def extract_leftovers(errors, index_objects_by_id)
           return [] unless @options[:update_fields].present? && @options[:update_failover] && errors.present?
 
+          puts "extract_leftovers"
           failed_partial_updates = errors.select do |item|
             item.keys.first == 'update' && item.values.first['error']['type'] == 'document_missing_exception'
           end

--- a/lib/chewy/type/import/routine.rb
+++ b/lib/chewy/type/import/routine.rb
@@ -78,6 +78,7 @@ module Chewy
         # @return [true, false] the result of the request, true if no errors
         def process(index: [], delete: [])
           bulk_builder = BulkBuilder.new(@type, index: index, delete: delete, fields: @options[:update_fields])
+          puts bulk_builder
           bulk_body = bulk_builder.bulk_body
 
           if @options[:journal]

--- a/lib/chewy/type/import/routine.rb
+++ b/lib/chewy/type/import/routine.rb
@@ -77,7 +77,6 @@ module Chewy
         # @param delete [Array<Object>] any acceptable objects for deleting
         # @return [true, false] the result of the request, true if no errors
         def process(index: [], delete: [])
-          puts "inside process"
           bulk_builder = BulkBuilder.new(@type, index: index, delete: delete, fields: @options[:update_fields])
           bulk_body = bulk_builder.bulk_body
 
@@ -118,15 +117,10 @@ module Chewy
         def extract_leftovers(errors, index_objects_by_id)
           return [] unless @options[:update_fields].present? && @options[:update_failover] && errors.present?
 
-          puts "errors #{errors}"
-          puts "@options[:update_failover] #{@options[:update_failover]}"
-          puts "extract_leftovers"
           failed_partial_updates = errors.select do |item|
             item.keys.first == 'update' && item.values.first['error']['type'] == 'document_missing_exception'
           end
-          puts "failed_partial_updates #{failed_partial_updates}"
           failed_ids_hash = failed_partial_updates.index_by { |item| item.values.first['_id'].to_s }
-          puts "failed_ids_hash #{failed_ids_hash}"
           failed_ids_for_reimport = failed_ids_hash.keys & index_objects_by_id.keys
           errors_to_cleanup = failed_ids_hash.values_at(*failed_ids_for_reimport)
           errors_to_cleanup.each { |error| errors.delete(error) }


### PR DESCRIPTION
Engineering teams need to use `update_fields` values in certain `crutches` to partially load the needed objects from Mongo

For example, data team wants to load `typed_custom_fields` crutch but does not need all the data needed for their field

> Crutch would get contact/account from FieldEnrichmentStatus and Contact/Account will have enriched_at date time fields...
But the crutch currently load Contact, Account, associated organizations, Places, Funding data etc which is not needed for me when I just want to update enriched_at partially using the crutch...