### PR TITLE
Amol/v7.6.0 fork

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,7 +49,7 @@ Metrics/AbcSize:
 # Offense count: 4
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 267
+  Max: 300
 
 # Offense count: 13
 # Configuration parameters: IgnoredMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -69,7 +69,7 @@ Metrics/ModuleLength:
 # Offense count: 18
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:
-  Max: 13
+  Max: 14
 
 # Offense count: 11
 # Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers.

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'activejob', require: false
 gem 'sidekiq', require: false
 
 gem 'kaminari-core', require: false
+gem 'mongoid'
 
 gem 'parallel', require: false
 gem 'ruby-progressbar', require: false

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -59,15 +59,15 @@ ActiveSupport.on_load(:active_record) do
   include Chewy::Index::Observe::ActiveRecordMethods
 end
 
-ActiveSupport.on_load(:mongoid) do
-  module Mongoid
-    module Document
-      module ClassMethods
-        include Chewy::Index::Observe::MongoidMethods
-      end
-    end
-  end
-end
+# ActiveSupport.on_load(:mongoid) do
+#   module Mongoid
+#     module Document
+#       module ClassMethods
+#         include Chewy::Index::Observe::MongoidMethods
+#       end
+#     end
+#   end
+# end
 
 module Chewy
   @adapters = [

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -36,6 +36,10 @@ ActiveSupport.on_load(:active_record) do
   try_require 'kaminari/activerecord'
 end
 
+ActiveSupport.on_load(:mongoid) do
+  try_require 'kaminari/mongoid'
+end
+
 require 'chewy/version'
 require 'chewy/errors'
 require 'chewy/config'
@@ -55,8 +59,19 @@ ActiveSupport.on_load(:active_record) do
   include Chewy::Index::Observe::ActiveRecordMethods
 end
 
+ActiveSupport.on_load(:mongoid) do
+  module Mongoid
+    module Document
+      module ClassMethods
+        include Chewy::Index::Observe::MongoidMethods
+      end
+    end
+  end
+end
+
 module Chewy
   @adapters = [
+    Chewy::Index::Adapter::Mongoid,
     Chewy::Index::Adapter::ActiveRecord,
     Chewy::Index::Adapter::Object
   ]

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -59,15 +59,15 @@ ActiveSupport.on_load(:active_record) do
   include Chewy::Index::Observe::ActiveRecordMethods
 end
 
-# ActiveSupport.on_load(:mongoid) do
-#   module Mongoid
-#     module Document
-#       module ClassMethods
-#         include Chewy::Index::Observe::MongoidMethods
-#       end
-#     end
-#   end
-# end
+ActiveSupport.on_load(:mongoid) do
+  module Mongoid
+    module Document
+      module ClassMethods
+        include Chewy::Index::Observe::MongoidMethods
+      end
+    end
+  end
+end
 
 module Chewy
   @adapters = [

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -119,7 +119,7 @@ module Chewy
       else
         'chewy_client'
       end
-      Chewy.current[thread_cache_key.to_sym] ||= Chewy::ElasticClient.new
+      Chewy.current[thread_cache_key.to_sym] ||= Chewy::ElasticClient.new(hosts)
     end
 
     # Sends wait_for_status request to ElasticSearch with status

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -112,7 +112,7 @@ module Chewy
 
     # Main elasticsearch-ruby client instance
     #
-    def client(hosts=nil)
+    def client(hosts = nil)
       #   # We are changing this to support multiple clusters in chewy.
       thread_cache_key = if hosts
         "chewy_client_#{hosts}"

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -70,12 +70,12 @@ module Chewy
     end
 
     def transport_logger=(logger)
-      Chewy.client.transport.transport.logger = logger
+      Chewy.client(@hosts_name).transport.transport.logger = logger
       @transport_logger = logger
     end
 
     def transport_tracer=(tracer)
-      Chewy.client.transport.transport.tracer = tracer
+      Chewy.client(@hosts_name).transport.transport.tracer = tracer
       @transport_tracer = tracer
     end
 

--- a/lib/chewy/elastic_client.rb
+++ b/lib/chewy/elastic_client.rb
@@ -9,9 +9,9 @@ module Chewy
       ::Elasticsearch::Client.new(client_configuration, &block)
     end
 
-    def initialize(elastic_client = nil, hosts = nil)
-      elastic_client ||= self.class.build_es_client(hosts)
-      @elastic_client = elastic_client
+    def initialize(hosts = nil)
+      @elastic_client ||= self.class.build_es_client(hosts)
+      @elastic_client
     end
 
   private

--- a/lib/chewy/elastic_client.rb
+++ b/lib/chewy/elastic_client.rb
@@ -1,14 +1,16 @@
 module Chewy
   # Replacement for Chewy.client
   class ElasticClient
-    def self.build_es_client(configuration = Chewy.configuration)
+    def self.build_es_client(hosts = nil, configuration = Chewy.configuration)
       client_configuration = configuration.deep_dup
+      client_configuration[:hosts] = client_configuration[hosts] if hosts
       client_configuration.delete(:prefix) # used by Chewy, not relevant to Elasticsearch::Client
       block = client_configuration[:transport_options].try(:delete, :proc)
       ::Elasticsearch::Client.new(client_configuration, &block)
     end
 
-    def initialize(elastic_client = self.class.build_es_client)
+    def initialize(elastic_client = nil, hosts = nil)
+      elastic_client ||= self.class.build_es_client(hosts)
       @elastic_client = elastic_client
     end
 

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -49,7 +49,6 @@ module Chewy
 
     class << self
       attr_reader :hosts_name
-
       # @overload index_name(suggest)
       #   If suggested name is passed, it is set up as the new base name for
       #   the index. Used for the index base name redefinition.

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -1,6 +1,7 @@
 require 'chewy/search'
 require 'chewy/index/actions'
 require 'chewy/index/adapter/active_record'
+require 'chewy/index/adapter/mongoid'
 require 'chewy/index/adapter/object'
 require 'chewy/index/aliases'
 require 'chewy/index/crutch'

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -50,6 +50,7 @@ module Chewy
 
     class << self
       attr_reader :hosts_name
+
       # @overload index_name(suggest)
       #   If suggested name is passed, it is set up as the new base name for
       #   the index. Used for the index base name redefinition.
@@ -97,7 +98,7 @@ module Chewy
       # Sets the hosts name of the index. If hosts_name is nil, use the default
       # hosts in chewy.yml. Otherwise use the hosts with the specified name for
       # indexing/queries.
-      def set_hosts_name(hosts_name)
+      def es_cluster_host(hosts_name)
         @hosts_name = hosts_name
       end
 

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -48,6 +48,8 @@ module Chewy
     self._default_import_options = {}
 
     class << self
+      attr_reader :hosts_name
+
       # @overload index_name(suggest)
       #   If suggested name is passed, it is set up as the new base name for
       #   the index. Used for the index base name redefinition.
@@ -90,6 +92,13 @@ module Chewy
             suffix
           ].reject(&:blank?).join('_')
         end
+      end
+
+      # Sets the hosts name of the index. If hosts_name is nil, use the default
+      # hosts in chewy.yml. Otherwise use the hosts with the specified name for
+      # indexing/queries.
+      def set_hosts_name(hosts_name)
+        @hosts_name = hosts_name
       end
 
       # Base name for the index. Uses the default value inferred from the

--- a/lib/chewy/index/adapter/mongoid.rb
+++ b/lib/chewy/index/adapter/mongoid.rb
@@ -40,7 +40,7 @@ module Chewy
             collection.is_a?(Array) &&
             !collection.empty? &&
             collection.all? { |item| item.is_a?(::Mongoid::Document) && item.__selected_fields.nil? }
-          options['direct_import'] = direct_import unless options[:direct_import].present?
+          options[:direct_import] = direct_import unless options[:direct_import].present?
           super
         end
 

--- a/lib/chewy/index/adapter/mongoid.rb
+++ b/lib/chewy/index/adapter/mongoid.rb
@@ -34,16 +34,6 @@ module Chewy
           end.all?
         end
 
-        def import_objects(collection, options)
-          direct_import = (default_scope.selector.empty? || @options[:searchable_proc]) &&
-            !options[:raw_import] &&
-            collection.is_a?(Array) &&
-            !collection.empty? &&
-            collection.all? { |item| item.is_a?(::Mongoid::Document) && item.__selected_fields.nil? }
-          options[:direct_import] = direct_import unless options[:direct_import].present?
-          super(collection, options)
-        end
-
         def primary_key
           :_id
         end

--- a/lib/chewy/index/adapter/mongoid.rb
+++ b/lib/chewy/index/adapter/mongoid.rb
@@ -34,6 +34,16 @@ module Chewy
           end.all?
         end
 
+        def import_objects(collection, options)
+          direct_import = (default_scope.selector.empty? || @options[:searchable_proc]) &&
+            !options[:raw_import] &&
+            collection.is_a?(Array) &&
+            !collection.empty? &&
+            collection.all? { |item| item.is_a?(::Mongoid::Document) && item.__selected_fields.nil? }
+          options['direct_import'] = direct_import unless options[:direct_import].present?
+          super
+        end
+
         def primary_key
           :_id
         end

--- a/lib/chewy/index/adapter/mongoid.rb
+++ b/lib/chewy/index/adapter/mongoid.rb
@@ -34,6 +34,16 @@ module Chewy
           end.all?
         end
 
+        def import_objects(collection, options)
+          direct_import = (default_scope.selector.empty? || @options[:searchable_proc]) &&
+            !options[:raw_import] &&
+            collection.is_a?(Array) &&
+            !collection.empty? &&
+            collection.all? { |item| item.is_a?(::Mongoid::Document) && item.__selected_fields.nil? }
+          options[:direct_import] = direct_import unless options[:direct_import].present?
+          super(collection, options)
+        end
+
         def primary_key
           :_id
         end

--- a/lib/chewy/index/adapter/mongoid.rb
+++ b/lib/chewy/index/adapter/mongoid.rb
@@ -41,7 +41,7 @@ module Chewy
             !collection.empty? &&
             collection.all? { |item| item.is_a?(::Mongoid::Document) && item.__selected_fields.nil? }
           options[:direct_import] = direct_import unless options[:direct_import].present?
-          super
+          super(collection, options)
         end
 
         def primary_key

--- a/lib/chewy/index/adapter/mongoid.rb
+++ b/lib/chewy/index/adapter/mongoid.rb
@@ -1,0 +1,77 @@
+require 'chewy/index/adapter/orm'
+
+module Chewy
+  class Index
+    module Adapter
+      class Mongoid < Orm
+        def self.accepts?(target)
+          defined?(::Mongoid::Document) && (
+            (target.is_a?(Class) && target.ancestors.include?(::Mongoid::Document)) ||
+              target.is_a?(::Mongoid::Criteria))
+        end
+
+        def identify(collection)
+          super(collection).map { |id| id.is_a?(BSON::ObjectId) ? id.to_s : id }
+        end
+
+      private
+
+        def cleanup_default_scope!
+          Chewy.logger.warn('Default type scope order, limit and offset are ignored and will be nullified') if Chewy.logger && sort_or_limit_or_skip_options?
+
+          @default_scope.options.delete(:limit)
+          @default_scope.options.delete(:skip)
+          @default_scope = @default_scope.reorder(nil)
+        end
+
+        def sort_or_limit_or_skip_options?
+          @default_scope.options.values_at(:sort, :limit, :skip).compact.present?
+        end
+
+        def import_scope(scope, options)
+          pluck_in_batches(scope, **options.slice(:batch_size)).map do |ids|
+            yield grouped_objects(default_scope_where_ids_in(ids))
+          end.all?
+        end
+
+        def primary_key
+          :_id
+        end
+
+        def pluck(scope, fields: [])
+          scope.pluck(primary_key, *fields)
+        end
+
+        def pluck_in_batches(scope, fields: [], batch_size: nil, **options, &block)
+          unless block_given?
+            return enum_for(
+              :pluck_in_batches,
+              scope,
+              fields: fields,
+              batch_size: batch_size,
+              **options
+            )
+          end
+
+          scope.batch_size(batch_size).no_timeout.pluck(primary_key, *fields).each_slice(batch_size, &block)
+        end
+
+        def scope_where_ids_in(scope, ids)
+          scope.where(primary_key.in => ids)
+        end
+
+        def all_scope
+          target.all
+        end
+
+        def relation_class
+          ::Mongoid::Criteria
+        end
+
+        def object_class
+          ::Mongoid::Document
+        end
+      end
+    end
+  end
+end

--- a/lib/chewy/index/adapter/orm.rb
+++ b/lib/chewy/index/adapter/orm.rb
@@ -113,19 +113,13 @@ module Chewy
       private
 
         def import_objects(collection, options)
-          direct_import = (default_scope.selector.empty? || @options[:searchable_proc]) &&
-            !options[:raw_import] &&
-            collection.is_a?(Array) &&
-            !collection.empty? &&
-            collection.all? { |item| item.is_a?(::Mongoid::Document) && item.__selected_fields.nil? }
-
           collection_ids = identify(collection)
           hash = collection_ids.map(&:to_s).zip(collection).to_h
 
           indexed = collection_ids.each_slice(options[:batch_size]).map do |ids|
             batch = if options[:raw_import]
               raw_default_scope_where_ids_in(ids, options[:raw_import])
-            elsif options[:direct_import] || direct_import
+            elsif options[:direct_import]
               hash.values_at(*ids.map(&:to_s))
             else
               default_scope_where_ids_in(ids)

--- a/lib/chewy/index/adapter/orm.rb
+++ b/lib/chewy/index/adapter/orm.rb
@@ -113,13 +113,19 @@ module Chewy
       private
 
         def import_objects(collection, options)
+          direct_import = (default_scope.selector.empty? || @options[:searchable_proc]) &&
+            !options[:raw_import] &&
+            collection.is_a?(Array) &&
+            !collection.empty? &&
+            collection.all? { |item| item.is_a?(::Mongoid::Document) && item.__selected_fields.nil? }
+
           collection_ids = identify(collection)
           hash = collection_ids.map(&:to_s).zip(collection).to_h
 
           indexed = collection_ids.each_slice(options[:batch_size]).map do |ids|
             batch = if options[:raw_import]
               raw_default_scope_where_ids_in(ids, options[:raw_import])
-            elsif options[:direct_import]
+            elsif options[:direct_import] || direct_import
               hash.values_at(*ids.map(&:to_s))
             else
               default_scope_where_ids_in(ids)

--- a/lib/chewy/index/adapter/orm.rb
+++ b/lib/chewy/index/adapter/orm.rb
@@ -124,7 +124,7 @@ module Chewy
             else
               default_scope_where_ids_in(ids)
             end
-
+            batch = batch.select { |object| @options[:searchable_proc].call(object) } if @options[:searchable_proc].present?
             if batch.empty?
               true
             else

--- a/lib/chewy/index/aliases.rb
+++ b/lib/chewy/index/aliases.rb
@@ -5,14 +5,14 @@ module Chewy
 
       module ClassMethods
         def indexes
-          indexes = empty_if_not_found { client.indices.get(index: index_name).keys }
-          indexes += empty_if_not_found { client.indices.get_alias(name: index_name).keys }
+          indexes = empty_if_not_found { client(@hosts_name).indices.get(index: index_name).keys }
+          indexes += empty_if_not_found { client(@hosts_name).indices.get_alias(name: index_name).keys }
           indexes.compact.uniq
         end
 
         def aliases
           empty_if_not_found do
-            client.indices.get_alias(index: index_name, name: '*').values.flat_map do |aliases|
+            client(@hosts_name).indices.get_alias(index: index_name, name: '*').values.flat_map do |aliases|
               aliases['aliases'].keys
             end
           end.compact.uniq

--- a/lib/chewy/index/crutch.rb
+++ b/lib/chewy/index/crutch.rb
@@ -26,7 +26,12 @@ module Chewy
         end
 
         def [](name)
-          @crutches_instances[name] ||= @index._crutches[:"#{name}"].call(@collection)
+          execution_block = @index._crutches[:"#{name}"]
+          @crutches_instances[name] ||= if execution_block.arity == 2
+            execution_block.call(@collection, self)
+          else
+            execution_block.call(@collection)
+          end
         end
       end
 

--- a/lib/chewy/index/import/bulk_request.rb
+++ b/lib/chewy/index/import/bulk_request.rb
@@ -33,7 +33,7 @@ module Chewy
           return [] if body.blank?
 
           request_bodies(body).each_with_object([]) do |request_body, results|
-            response = @index.client.bulk(**request_base.merge(body: request_body)) if request_body.present?
+            response = @index.client(@index.hosts_name).bulk(**request_base.merge(body: request_body)) if request_body.present?
 
             next unless response.try(:[], 'errors')
 

--- a/lib/chewy/index/observe/mongoid_methods.rb
+++ b/lib/chewy/index/observe/mongoid_methods.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Chewy
+  class Index
+    module Observe
+      extend Helpers
+      module MongoidMethods
+        class_methods do
+          def update_index(type_name, *args, &block)
+            # callback_options = Observe.extract_callback_options!(args)
+            # update_proc = Observe.update_proc(type_name, *args, &block)
+            #
+            # after_save(callback_options, &update_proc)
+            # after_destroy(callback_options, &update_proc)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/chewy/index/syncer.rb
+++ b/lib/chewy/index/syncer.rb
@@ -208,7 +208,7 @@ module Chewy
         return @outdated_sync_field_type if instance_variable_defined?(:@outdated_sync_field_type)
         return unless @index.outdated_sync_field
 
-        mappings = @index.client.indices.get_mapping(index: @index.index_name).values.first.fetch('mappings', {})
+        mappings = @index.client(@index.hosts_name).indices.get_mapping(index: @index.index_name).values.first.fetch('mappings', {})
 
         @outdated_sync_field_type = mappings
           .fetch('properties', {})

--- a/lib/chewy/multi_search.rb
+++ b/lib/chewy/multi_search.rb
@@ -52,7 +52,7 @@ module Chewy
         [rendered.except(:body), rendered[:body]]
       end
 
-      client.msearch(body: body)
+      client(@hosts_name).msearch(body: body)
     end
   end
 

--- a/lib/chewy/runtime.rb
+++ b/lib/chewy/runtime.rb
@@ -2,7 +2,7 @@ require 'chewy/runtime/version'
 
 module Chewy
   module Runtime
-    def self.version(hosts=nil)
+    def self.version(hosts = nil)
       Chewy.current[:chewy_runtime_version] ||= Version.new(Chewy.client(hosts).info['version']['number'])
     end
   end

--- a/lib/chewy/runtime.rb
+++ b/lib/chewy/runtime.rb
@@ -2,8 +2,8 @@ require 'chewy/runtime/version'
 
 module Chewy
   module Runtime
-    def self.version
-      Chewy.current[:chewy_runtime_version] ||= Version.new(Chewy.client.info['version']['number'])
+    def self.version(hosts=nil)
+      Chewy.current[:chewy_runtime_version] ||= Version.new(Chewy.client(hosts).info['version']['number'])
     end
   end
 end

--- a/lib/chewy/search.rb
+++ b/lib/chewy/search.rb
@@ -49,7 +49,7 @@ module Chewy
       # @return [Hash] the request result
       def search_string(query, options = {})
         options = options.merge(all.render.slice(:index).merge(q: query))
-        Chewy.client.search(options)
+        Chewy.client(@hosts_name).search(options)
       end
 
       # Delegates methods from the request class to the index class

--- a/lib/chewy/search/parameters.rb
+++ b/lib/chewy/search/parameters.rb
@@ -98,7 +98,7 @@ module Chewy
       def merge!(other)
         other.storages.each do |name, storage|
           # Handle query-related storages with a specialized merge function
-          if name.to_sym.in?([:query, :filter, :post_filter])
+          if name.to_sym.in? %i[query filter post_filter]
             merge_queries_and_filters(name, storage)
           else
             # For other types of storages, use a general purpose merge method
@@ -145,9 +145,7 @@ module Chewy
 
       def render_body(replace_post_filter: false)
         exceptions = %i[filter query none] + QUERY_STRING_STORAGES
-        if replace_post_filter
-          exceptions += %i[post_filter]
-        end
+        exceptions += %i[post_filter] if replace_post_filter
         body = @storages.except(*exceptions).values.inject({}) do |result, storage|
           result.merge!(storage.render || {})
         end
@@ -184,7 +182,6 @@ module Chewy
           {query: {bool: filter}}
         end
       end
-
 
     private
 
@@ -282,9 +279,7 @@ module Chewy
         else
           # Default merge if one is nil
           replacement_query = current_query || other_query
-          if replacement_query
-            storages[name].replace!(replacement_query)
-          end
+          storages[name].replace!(replacement_query) if replacement_query
         end
       end
 

--- a/lib/chewy/search/parameters.rb
+++ b/lib/chewy/search/parameters.rb
@@ -97,7 +97,6 @@ module Chewy
       # @return [{Symbol => Chewy::Search::Parameters::Storage}] storages from other parameters
       def merge!(other)
         other.storages.each do |name, storage|
-          modify!(name) { merge!(storage) }
           # Handle query-related storages with a specialized merge function
           if name.to_sym.in?([:query, :filter, :post_filter])
             merge_queries_and_filters(name, storage)

--- a/lib/chewy/search/parameters.rb
+++ b/lib/chewy/search/parameters.rb
@@ -98,14 +98,21 @@ module Chewy
       def merge!(other)
         other.storages.each do |name, storage|
           modify!(name) { merge!(storage) }
+          # Handle query-related storages with a specialized merge function
+          if name.to_sym.in?([:query, :filter, :post_filter])
+            merge_queries_and_filters(name, storage)
+          else
+            # For other types of storages, use a general purpose merge method
+            modify!(name) { merge!(storage) }
+          end
         end
       end
 
       # Renders and merges all the parameter storages into a single hash.
       #
       # @return [Hash] request body
-      def render
-        render_query_string_params.merge(render_body)
+      def render(replace_post_filter: false)
+        render_query_string_params.merge(render_body(replace_post_filter: replace_post_filter))
       end
 
     protected
@@ -137,16 +144,19 @@ module Chewy
         end
       end
 
-      def render_body
+      def render_body(replace_post_filter: false)
         exceptions = %i[filter query none] + QUERY_STRING_STORAGES
+        if replace_post_filter
+          exceptions += %i[post_filter]
+        end
         body = @storages.except(*exceptions).values.inject({}) do |result, storage|
           result.merge!(storage.render || {})
         end
-        body.merge!(render_query || {})
+        body.merge!(render_query(replace_post_filter: replace_post_filter) || {})
         {body: body}
       end
 
-      def render_query
+      def render_query(replace_post_filter: false)
         none = @storages[:none].render
 
         return none if none
@@ -154,6 +164,16 @@ module Chewy
         filter = @storages[:filter].render
         query = @storages[:query].render
 
+        if replace_post_filter
+          post_filter = @storages[:post_filter].render
+          if post_filter
+            query = if query
+              {query: {bool: {must: [query[:query], post_filter[:post_filter]]}}}
+            else
+              {query: {bool: {must: [post_filter[:post_filter]]}}}
+            end
+          end
+        end
         return query unless filter
 
         if query && query[:query][:bool]
@@ -163,6 +183,119 @@ module Chewy
           {query: {bool: {must: query[:query]}.merge!(filter)}}
         else
           {query: {bool: filter}}
+        end
+      end
+
+
+    private
+
+      # Smartly wraps a query in a bool must unless it is already correctly structured.
+      # This method helps maintain logical grouping and avoid unnecessary nesting in queries.
+      #
+      # @param [Hash, Array, Nil] query The query to wrap.
+      # @return [Hash, Array, Nil] The wrapped or original query.
+      #
+      # Example:
+      #   input: { term: { status: 'active' } }
+      #   output: { bool: { must: [{ term: { status: 'active' } }] } }
+      #
+      #   input: { bool: { must: [{ term: { status: 'active' } }] } }
+      #   output: { bool: { must: [{ term: { status: 'active' } }] } }
+      def smart_wrap_in_bool_must(query = nil)
+        return nil if query.nil?
+
+        query = query.deep_symbolize_keys if query.is_a?(Hash)
+
+        # Normalize to ensure it's always in an array form for 'must' unless already properly formatted.
+        normalized_query = query.is_a?(Array) ? query : [query]
+
+        # Check if the query already has a 'bool' structure
+        if query.is_a?(Hash) && query.key?(:bool)
+          # Check the components of the 'bool' structure
+          has_only_must = query[:bool].key?(:must) && query[:bool].keys.size == 1
+
+          # If it has only a 'must' and nothing else, use it as is
+          if has_only_must
+            query
+          else
+            # If it contains other components like 'should' or 'must_not', wrap in a new 'bool' 'must'
+            {bool: {must: normalized_query}}
+          end
+        else
+          # If no 'bool' structure is present, wrap the query in a 'bool' 'must'
+          {bool: {must: normalized_query}}
+        end
+      end
+
+      # Combines two boolean queries into a single well-formed boolean query without redundant nesting.
+      #
+      # @param [Hash, Array] query1 The first query component.
+      # @param [Hash, Array] query2 The second query component.
+      # @return [Hash] A combined boolean query.
+      #
+      # Example:
+      #   query1: { bool: { must: [{ term: { status: 'active' } }] } }
+      #   query2: { bool: { must: [{ term: { age: 25 } }] } }
+      #   result: { bool: { must: [{ term: { status: 'active' } }, { term: { age: 25 } }] } }
+      def merge_bool_queries(query1, query2)
+        # Extract the :must components, ensuring they are arrays. ideally this should be the case anyway
+        # but this is a safety check for cases like OrganizationChartFilter where the query is not properly formatted.
+        #      Eg  index.query(
+        #             {
+        #               bool: {
+        #                 must: {
+        #                   term: {
+        #                     has_org_chart_note: has_org_chart_note
+        #                   }
+        #                 },
+        #               }
+        #             }
+        #           )
+        must1 = ensure_array(query1.dig(:bool, :must))
+        must2 = ensure_array(query2.dig(:bool, :must))
+
+        # Combine the arrays; if both are empty, wrap the entire queries as fallback.
+        if must1.empty? && must2.empty?
+          {bool: {must: [query1, query2].compact}} # Use compact to remove any nils.
+        else
+          {bool: {must: must1 + must2}}
+        end
+      end
+
+      # Merges queries or filters from two different storages into a single storage efficiently.
+      #
+      # @param [Symbol] name The type of storage (query, filter, post_filter).
+      # @param [Storage] other_storage The storage object from another instance.
+      def merge_queries_and_filters(name, other_storage)
+        current_storage = storages[name]
+        # other_storage = other.storages[name]
+        # Render each storage to get the DSL
+        current_query = smart_wrap_in_bool_must(current_storage.render&.[](name))
+        other_query = smart_wrap_in_bool_must(other_storage.render&.[](name))
+
+        if current_query && other_query
+          # Custom merging logic for queries and filters
+
+          # Combine rendered queries inside a single bool must
+          combined_storage = merge_bool_queries(current_query, other_query)
+
+          storages[name].replace!(combined_storage) # Directly set the modified storage
+        else
+          # Default merge if one is nil
+          replacement_query = current_query || other_query
+          if replacement_query
+            storages[name].replace!(replacement_query)
+          end
+        end
+      end
+
+      # Helper to ensure the :must key is always an array
+      def ensure_array(value)
+        case value
+        when Hash, nil
+          [value].compact # Wrap hashes or non-nil values in an array, remove nils.
+        else
+          value
         end
       end
     end

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -571,7 +571,7 @@ module Chewy
       #   @return [Chewy::Search::Request]
       %i[source stored_fields].each do |name|
         define_method(name) do |value, *values|
-          modify(name) { update!([value, *values, '_index_type']) }
+          modify(name) { update!([*value, *values, '_index_type']) }
         end
       end
 

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -874,9 +874,8 @@ module Chewy
           count_params.merge!({opaque_id: @x_opaque_id}) if @x_opaque_id
           Chewy.client(_indices.first.hosts_name).count(count_params)['count']
         end
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
-        # passing error as a separate param down to the response, hence won't affect any other logic
-        { "not_found_error" => error }
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound
+        0
       end
 
       # Checks if any of the document exist for this request. If

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -571,7 +571,7 @@ module Chewy
       #   @return [Chewy::Search::Request]
       %i[source stored_fields].each do |name|
         define_method name do |value, *values|
-          modify(name) { update!(values.empty? ? value : [value, *values]) }
+          modify(name) { update!(['_index_type', *value, *values]) }
         end
       end
 

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -571,7 +571,8 @@ module Chewy
       #   @return [Chewy::Search::Request]
       %i[source stored_fields].each do |name|
         define_method name do |value, *values|
-          modify(name) { update!(['_index_type', *value, *values]) }
+          values << '_index_type'
+          modify(name) { update!([value, *values]) }
         end
       end
 

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -570,9 +570,8 @@ module Chewy
       #   @param values [true, false, String, Symbol, Array<String, Symbol>]
       #   @return [Chewy::Search::Request]
       %i[source stored_fields].each do |name|
-        define_method name do |value, *values|
-          values << '_index_type'
-          modify(name) { update!([value, *values]) }
+        define_method(name) do |value, *values|
+          modify(name) { update!([value, *values, '_index_type']) }
         end
       end
 

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -77,7 +77,7 @@ module Chewy
         @parameters ||= Parameters.new
       end
 
-      def set_x_opaque_id(x_opaque_id)
+      def x_opaque_id(x_opaque_id)
         @x_opaque_id = x_opaque_id
       end
 

--- a/lib/chewy/search/scrolling.rb
+++ b/lib/chewy/search/scrolling.rb
@@ -44,7 +44,7 @@ module Chewy
           result = perform_scroll(scroll: scroll, scroll_id: scroll_id)
         end
       ensure
-        Chewy.client.clear_scroll(body: {scroll_id: scroll_id}) if scroll_id
+        Chewy.client(@hosts_name).clear_scroll(body: {scroll_id: scroll_id}) if scroll_id
       end
 
       # @!method scroll_hits(batch_size: 1000, scroll: '1m')
@@ -129,7 +129,7 @@ module Chewy
 
       def perform_scroll(body)
         ActiveSupport::Notifications.instrument 'search_query.chewy', notification_payload(request: body) do
-          Chewy.client.scroll(body)
+          Chewy.client(@hosts_name).scroll(body)
         end
       end
     end


### PR DESCRIPTION
This PR uses the toptal/chewy's 7.6.0 tag release as used in toptal_master branch and applies apollo specific changes required on it.

1. Added support for multiple hosts
2. Added searchable proc support - This is used to pass context of valid documents for index while reindexing
3. Mongoid support was dropped in Chewy 7. We have added the adapter again along with feature parity from our current forked version
4. Custom merge strategy for avoiding unnecessary nesting
5. Added _index_type specific changes
6. Some changes related to x_opaque_id
7. Support for replace_post_filter

