### PR TITLE
[PLAT-695] Passing error down to Chewy Response to be accessible

### DIFF
--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -46,7 +46,7 @@ module Chewy
 
       delegate :hits, :wrappers, :objects, :records, :documents,
         :object_hash, :record_hash, :document_hash,
-        :total, :max_score, :took, :timed_out?, to: :response
+        :total, :max_score, :took, :timed_out?, :error, to: :response
       delegate :each, :size, :to_a, :[], to: :wrappers
       alias_method :to_ary, :to_a
       alias_method :total_count, :total
@@ -990,8 +990,9 @@ module Chewy
                 request_body.merge!({opaque_id: @x_opaque_id})
               end
               Chewy.client(_indices.first.hosts_name).search(request_body)
-            rescue Elasticsearch::Transport::Transport::Errors::NotFound
-              {}
+            rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
+              # passing error as a separate param down to the response, hence won't affect any other logic
+              { error: }
             end
           end
       end

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -46,7 +46,7 @@ module Chewy
 
       delegate :hits, :wrappers, :objects, :records, :documents,
         :object_hash, :record_hash, :document_hash,
-        :total, :max_score, :took, :timed_out?, :error, to: :response
+        :total, :max_score, :took, :timed_out?, :errors, to: :response
       delegate :each, :size, :to_a, :[], to: :wrappers
       alias_method :to_ary, :to_a
       alias_method :total_count, :total
@@ -992,7 +992,7 @@ module Chewy
               Chewy.client(_indices.first.hosts_name).search(request_body)
             rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
               # passing error as a separate param down to the response, hence won't affect any other logic
-              { "error" => error }
+              { "errors" => [error] }
             end
           end
       end

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -992,7 +992,7 @@ module Chewy
               Chewy.client(_indices.first.hosts_name).search(request_body)
             rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
               # passing error as a separate param down to the response, hence won't affect any other logic
-              { error: }
+              { "error" => error }
             end
           end
       end

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -992,7 +992,7 @@ module Chewy
               Chewy.client(_indices.first.hosts_name).search(request_body)
             rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
               # passing error as a separate param down to the response, hence won't affect any other logic
-              { "errors" => [error] }
+              { "not_found_error" => error }
             end
           end
       end

--- a/lib/chewy/search/response.rb
+++ b/lib/chewy/search/response.rb
@@ -42,6 +42,8 @@ module Chewy
       # Response `errors` field. Returns `nil` if there is no error.
       # @return [Hash, nil]
       def errors
+        return nil if @body.blank?
+
         not_found_error = @body['not_found_error']
         # there's another case when failures could be present in some shards, in that case es returns them
         # in @body[_shards][failures] array

--- a/lib/chewy/search/response.rb
+++ b/lib/chewy/search/response.rb
@@ -20,7 +20,7 @@ module Chewy
       end
 
       # Raw response body obtained from ES.
-      # @param [Hash, nil]
+      # @return [Hash, nil]
       def body
         @body
       end

--- a/lib/chewy/search/response.rb
+++ b/lib/chewy/search/response.rb
@@ -40,14 +40,16 @@ module Chewy
       end
 
       # Response `errors` field. Returns `nil` if there is no error.
-      # @return [Array, nil]
+      # @return [Hash, nil]
       def errors
-        errors = Array(@body['errors'])
+        not_found_error = @body['not_found_error']
         # there's another case when failures could be present in some shards, in that case es returns them
         # in @body[_shards][failures] array
-        errors += Array(@body['_shards']['failures']) if @body['_shards']
-        # presence will return nil if array is empty
-        errors.compact.presence
+        shard_failures = @body['_shards']['failures'] if @body['_shards']
+        {
+          not_found_error: not_found_error,
+          shard_failures: shard_failures
+        }.compact.presence
       end
 
       # Duration of the request handling in ms according to ES.

--- a/lib/chewy/search/response.rb
+++ b/lib/chewy/search/response.rb
@@ -19,6 +19,12 @@ module Chewy
         @hits ||= hits_root['hits'] || []
       end
 
+      # Raw response body obtained from ES.
+      # @param [Hash, nil]
+      def body
+        @body
+      end
+
       # Response `total` field. Returns `0` if something went wrong.
       #
       # @return [Integer]
@@ -31,6 +37,12 @@ module Chewy
       # @return [Float]
       def max_score
         @max_score ||= hits_root['max_score']
+      end
+
+      # Response `error` field. Returns `nil` if there is no error.
+      # @return [Hash, nil]
+      def error
+        @error ||= @body['error']
       end
 
       # Duration of the request handling in ms according to ES.

--- a/lib/chewy/search/response.rb
+++ b/lib/chewy/search/response.rb
@@ -39,10 +39,15 @@ module Chewy
         @max_score ||= hits_root['max_score']
       end
 
-      # Response `error` field. Returns `nil` if there is no error.
-      # @return [Hash, nil]
-      def error
-        @error ||= @body['error']
+      # Response `errors` field. Returns `nil` if there is no error.
+      # @return [Array, nil]
+      def errors
+        errors = Array(@body['errors'])
+        # there's another case when failures could be present in some shards, in that case es returns them
+        # in @body[_shards][failures] array
+        errors += Array(@body['_shards']['failures']) if @body['_shards']
+        # presence will return nil if array is empty
+        errors.compact.presence
       end
 
       # Duration of the request handling in ms according to ES.


### PR DESCRIPTION
### Description
Currently, if the error raised from the ES client is of type `Elasticsearch::Transport::Transport::Errors::NotFound` then Chewy is not returning it to us.

Another case is when some shards experience failures - [here's this example](https://github.com/apolloio/chewy/pull/16#discussion_r1820679035).

```ruby
irb(main):4141> que = ContactsIndex.query(ids: { values: [] })
=> <ContactsIndex::Query {:index=>["contacts"], :body=>{:query=>{:ids=>{:values=>[]}}}}>
irb(main):4142> 
irb(main):4143> que.hits
D, [2024-10-29T12:35:51.865926 #55546] DEBUG -- Chewy:   ContactsIndex::Contact Search (1290.9ms) {:index=>["contacts"], :body=>{:query=>{:ids=>{:values=>[]}}}}
=> []
irb(main):4144> 
irb(main):4145> que.response
=> #<Chewy::Search::Response:0x0000000396e96788 @body={}, @error=nil, @loader=#<Chewy::Search::Loader:0x0000000396e96828 @except=[], @indexes=[ContactsIndex], @only=[], @options={}>, @paginator=#<Proc:0x00000003d7eb49e0 (lambda)>>
irb(main):4146> 
irb(main):4147> Chewy.client.search(que.render)
/Users/shivam/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/bundler/gems/elasticsearch-ruby-973646967537/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb:205:in `__raise_transport_error': [404] {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [contacts]","resource.type":"index_or_alias","resource.id":"contacts","index_uuid":"_na_","index":"contacts"}],"type":"index_not_found_exception","reason":"no such index [contacts]","resource.type":"index_or_alias","resource.id":"contacts","index_uuid":"_na_","index":"contacts"},"status":404} (Elasticsearch::Transport::Transport::Errors::NotFound)
irb(main):4148> 
```

To handle this change, I have passed any error received down to the Response and exposed the method for us to add logs or handle them properly. Overall, have made three changes:
1. Passed down the errors from the Chewy request to response
2. Exposed two methods in Chewy Response: `body` and `errors`
3. Delegated `errors` method in Chewy Request to it's Response – for direct usage

**Hence now, for the same example:** 
The resultant behaviour of other methods is the same but we are able to see ES errors: 
```ruby
irb(main):5564> que = ContactsIndex.query(ids: { values: [] })
=> <ContactsIndex::Query {:index=>["contacts"], :body=>{:query=>{:ids=>{:values=>[]}}}}>
irb(main):5565> 
irb(main):5566> que.hits
D, [2024-10-29T12:44:36.452627 #55546] DEBUG -- Chewy:   ContactsIndex::Contact Search (1096.4ms) {:index=>["contacts"], :body=>{:query=>{:ids=>{:values=>[]}}}}
=> []
irb(main):5567> 
irb(main):5568> que.response
=> 
#<Chewy::Search::Response:0x00000003f30501f8
 @body=
  {"error"=>
    #<Elasticsearch::Transport::Transport::Errors::NotFound: [404] {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [contacts]","resource.type":"index_or_alias","resource.id":"contacts","index_uuid":"_na_","index":"contacts"}],"type":"index_not_found_exception","reason":"no such index [contacts]","resource.type":"index_or_alias","resource.id":"contacts","index_uuid":"_na_","index":"contacts"},"status":404}>},
 @hits=[],
 @loader=#<Chewy::Search::Loader:0x00000003f3050298 @except=[], @indexes=[ContactsIndex], @only=[], @options={}>,
 @paginator=#<Proc:0x00000003ee370c98 (lambda)>>
irb(main):5569> 
irb(main):5570> que.error
=> #<Elasticsearch::Transport::Transport::Errors::NotFound: [404] {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [contacts]","resource.type":"index_or_alias","resource.id":"contacts","index_uuid":"_na_","index":"contacts"}],"type":"index_not_found_exception","reason":"no such index [contacts]","resource.type":"index_or_alias","resource.id":"contacts","index_uuid":"_na_","index":"contacts"},"status":404}>
irb(main):5571> 
irb(main):5572> Chewy.client.search(que.render)
/Users/shivam/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/bundler/gems/elasticsearch-ruby-973646967537/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb:205:in `__raise_transport_error': [404] {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [contacts]","resource.type":"index_or_alias","resource.id":"contacts","index_uuid":"_na_","index":"contacts"}],"type":"index_not_found_exception","reason":"no such index [contacts]","resource.type":"index_or_alias","resource.id":"contacts","index_uuid":"_na_","index":"contacts"},"status":404} (Elasticsearch::Transport::Transport::Errors::NotFound)
irb(main):5573> 
```


### Why is it needed?
We have some cases where we are getting some inconsistent nil responses in ES queries, I suspect that we are receiving some errors that are not propagated to us:
- https://apolloio.slack.com/archives/CQGC93J94/p1730112155349049
- https://apolloio.sentry.io/issues/5726154226/?project=4504093456334848&referrer=jira_integration
