### PR TITLE
Update crutch.rb: reverted update_fields 3rd param, as it is a property of crutch

### DIFF
--- a/lib/chewy/index/crutch.rb
+++ b/lib/chewy/index/crutch.rb
@@ -30,9 +30,7 @@ module Chewy
 
         def [](name)
           execution_block = @index._crutches[:"#{name}"]
-          @crutches_instances[name] ||= if execution_block.arity == 3
-            execution_block.call(@collection, self, @update_fields)
-          elsif execution_block.arity == 2
+          @crutches_instances[name] ||= if execution_block.arity == 2
             execution_block.call(@collection, self)
           else
             execution_block.call(@collection)


### PR DESCRIPTION

`update_fields` is a property of crutch, no need to pass it to crutch execution call
-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
